### PR TITLE
Enable right-click-drag resizing from any corner or side

### DIFF
--- a/Afloat.h
+++ b/Afloat.h
@@ -12,14 +12,33 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 #import <Cocoa/Cocoa.h>
 
+enum ResizeDirectionX {
+    right,
+    left,
+    noX
+};
+
+enum ResizeSectionY {
+    top,
+    bottom,
+    noY
+} ;
+
+struct ResizeSection {
+    enum ResizeDirectionX xResizeDirection;
+    enum ResizeSectionY yResizeDirection;
+};
 
 @interface Afloat : NSObject {
 	IBOutlet NSMenu* _menuWithItems;
 	BOOL _settingOverlay;
+    struct ResizeSection _resizeSection;
 }
 
 + (id) sharedInstance;
 - (NSBundle*) bundle;
+
+@property struct ResizeSection resizeSection;
 
 - (IBAction) toggleAlwaysOnTop:(id) sender;
 - (void) setKeptAfloat:(BOOL) afloat forWindow:(NSWindow*) c showBadgeAnimation:(BOOL) animated;

--- a/Afloat.m
+++ b/Afloat.m
@@ -55,6 +55,8 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 
 @implementation Afloat
 
+@synthesize resizeSection = _resizeSection;
+
 + (id) sharedInstance {
 	static id myself = nil;
 	if (!myself) myself = [self new];
@@ -502,8 +504,48 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 			}
 				
 			case NSLeftMouseDown:
-			case NSRightMouseDown:
-				return; // filter it
+                return; // filter it
+			case NSRightMouseDown: {
+                // on right click, record which direction we should resize in on the drag
+                
+                wnd = [evt window];
+
+                struct ResizeSection resizeSection;
+
+                NSPoint clickPoint = [evt locationInWindow];
+
+                NSSize wndSize = [wnd frame].size;
+
+                if (clickPoint.x < wndSize.width/3) {
+                    resizeSection.xResizeDirection = left;
+                } else if (clickPoint.x > 2*wndSize.width/3) {
+                    resizeSection.xResizeDirection = right;
+                } else {
+                    resizeSection.xResizeDirection = noX;
+                }
+
+                if (clickPoint.y < wndSize.height/3) {
+                    resizeSection.yResizeDirection = bottom;
+                } else  if (clickPoint.y > 2*wndSize.height/3) {
+                    resizeSection.yResizeDirection = top;
+                } else {
+                    resizeSection.yResizeDirection = noY;
+                }
+                
+                // special case for clicks in the "center" of the window
+                if (resizeSection.xResizeDirection == noX && resizeSection.yResizeDirection == noY) {
+                    // we choose either top resize or bottom resize depending on whether the click was above the middle or below
+                    if (clickPoint.y < wndSize.height/2) {
+                        resizeSection.yResizeDirection = bottom;
+                    } else {
+                        resizeSection.yResizeDirection = top;
+                    }
+                }
+
+                [hub setResizeSection:resizeSection];
+
+                return; // filter it
+            }
 				
 			case NSLeftMouseDragged: {
 				wnd = [evt window];
@@ -518,24 +560,61 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 				
 			case NSRightMouseDragged: {
 				wnd = [evt window];
+                struct ResizeSection resizeSection = [hub resizeSection];
 				if ([hub isWindowIgnoredByAfloat:wnd]) wnd = [hub currentWindow];
-			
+                
 				if (wnd && ([wnd styleMask] & NSResizableWindowMask)) {
-					NSSize minSize = [wnd minSize];
-					
-					frame = [wnd frame];
-					frame.size.width += [evt deltaX];
-					frame.size.height += [evt deltaY];
-					
-					if (frame.size.width < minSize.width)
-						frame.size.width = minSize.width;
-					
-					if (frame.size.height < minSize.height)
-						frame.size.height = minSize.height;
-					else
-						frame.origin.y -= [evt deltaY];
-					
-					[wnd setFrame:frame display:YES];
+
+                    NSSize minSize = [wnd minSize];
+
+                    frame = [wnd frame];
+                    
+                    switch (resizeSection.xResizeDirection) {
+                        case right:
+                            frame.size.width += [evt deltaX];
+                            if (frame.size.width < minSize.width) {
+                                frame.size.width = minSize.width;
+                            }
+                            break;
+                        case left:
+                            frame.size.width -= [evt deltaX];
+                            if (frame.size.width < minSize.width) {
+                                frame.size.width = minSize.width;
+                            } else {
+                                frame.origin.x += [evt deltaX];
+                            }
+                            break;
+                        case noX:
+                            // nothing to do
+                            break;
+                        default:
+                            [NSException raise:@"Unknown xResizeSection" format:@"No case for %d", resizeSection.xResizeDirection];
+                    }
+                    
+                    switch (resizeSection.yResizeDirection) {
+                        case top:
+                            frame.size.height -= [evt deltaY];
+                            if (frame.size.height < minSize.height) {
+                                frame.size.height = minSize.height;
+                            }
+                            break;
+                        case bottom:
+                            frame.size.height += [evt deltaY];
+                            if (frame.size.height < minSize.height) {
+                                frame.size.height = minSize.height;
+                            } else {
+                                frame.origin.y -= [evt deltaY];
+                            }
+                            break;
+                        case noY:
+                            // nothing to do
+                            break;
+                        default:
+                            [NSException raise:@"Unknown yResizeSection" format:@"No case for %d", resizeSection.yResizeDirection];
+                    }
+
+                    [wnd setFrame:frame display:YES];
+
 					return; // filter it once done
 				}
 			}
@@ -547,7 +626,7 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
 			case NSScrollWheel: {
 				wnd = [evt window];
 				if ([hub isWindowIgnoredByAfloat:wnd]) wnd = [hub currentWindow];
-				
+
 				[hub setAlphaValueByDelta:([evt deltaY] * 0.10) forWindow:wnd animate:NO];
 				return; // filter it
 			}


### PR DESCRIPTION
Thanks for the great utility; it has played a hugely important role in helping me adjust to a Mac after years of Linux addiction.

I've been running with the enhancement in this pull request for a while to make Afloat click-anywhere resizing even more like most X-based window managers: depending on where your mouse is when you right-click, the drag-resize affects the logical side/corner of the window.  I based this behavior on how the Alt-Click resizing works in XFCE, KDE and Gnome 2.

A bit more precisely: Imagine dividing the window into nine click "zones" by cutting the width into thirds and the height into thirds. Now, right-clicking the top-left "zone" will result in a resize which acts as if you had grabbed the top left corner of the window.  Alternatively, if you right-click on the top-middle "zone", this results in a resize which acts as if you had grabbed the top edge of the window.  That make sense?  Probably easier to just play with it than try and unravel that explanation...
